### PR TITLE
change the ordering of steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ const router = (req, res) => {
 const router = (req, res) => {
   if (req.url == '/') {
     res.writeHead(200, {'content-type' : "text/html"})
-    respone.end('Hello')
+    response.end('Hello')
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ You can view the full request/response values available in shots [demonstration]
 
 # Walkthrough
 
-- Create a new directory and run `npm init` to set up blank project with a package.json.
+- Create a new directory, move into it, and then set up blank node project with a package.json
+```
+mkdir <<name of directory>> && cd <<name of directory>>
+```
+```
+npm init
+```
 - Create a server file (not strictly necessary in this walkthrough but you might as well get the practice of doing a full set up), and enter the necessary code to get your server running;
 ```
 $ touch server.js

--- a/router.js
+++ b/router.js
@@ -1,11 +1,11 @@
-const router = (request, response) => {
-  if (request.url == '/') {
-    response.writeHead(200, {'content-type' : "text/html"})
-    response.end('Hello')
-  } else if (request.url =='/blog') {
-    response.writeHead(200, {'content-type' : "text/html"})
-    response.end('Blog')
-  } 
+const router = (req, res) => {
+  if (req.url == '/') {
+    res.writeHead(200, {'content-type' : "text/html"})
+    res.end('Hello')
+  } else if (req.url =='/blog') {
+    res.writeHead(200, {'content-type' : "text/html"})
+    res.end('Blog')
+  }
 }
 
 module.exports = router;


### PR DESCRIPTION
I realise that my suggestions were somewhat time consuming (and provided very last minute) so I've created this PR just to help out. But I won't be _remotely_ offended if you don't want to merge this in. It's a truly excellent workshop, I appreciate how much work has gone into this, and you may not agree with everything I've added / changed.

But, having gone through the workshop myself, I thought that some small adjustments to the ordering could just provide a bit of clarification for a newbie:
+ Remind students to `cd` into their new directory before running `npm init`
+ Remove the example code just before "Walkthrough" (see issue #9 for my reasoning)
+ Move the example contents of `server.js` to the part where a student creates the file
+ Replace `(request, response)` with `(req, res)` for consistency
+ Provide a short explanation for why they still want to set up a running server, even though it's not strictly necessary in a testing workshop
+ Ask students to run `npm start` just to make sure the code they have written works
+ Move creation of `router.js` until after installation of dependencies, and after the creation of the basic tape test
+ Make requiring the router in `test.js` a step of it's own as a little reminder, since there is a tendency for this to get missed when you're starting out
+ Break down the first shot test into lines (using inspiration from the way you broke down the first route that they write) and break down the explanations that you provided accordingly

Fixes #9 